### PR TITLE
Add deb packaging & publishing to packagecloud

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
+  build-linux-armv5:
+    name: linux/armv5
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout repository
@@ -24,10 +25,39 @@ jobs:
           ./autogen.sh
           ./configure --enable-static
           make
+          mv ico ico-dvd
+          chmod +x ico-dvd
           EOF
-      - name: Save artifacts
+      -
+        name: Prepare go-bin-deb
+        run: |
+          wget https://github.com/mh-cbon/go-bin-deb/releases/download/0.0.19/go-bin-deb-amd64.deb && \
+          sudo apt -y install ./go-bin-deb-amd64.deb && \
+          rm go-bin-deb-amd64.deb && \
+          sudo chmod +x ico-dvd && \
+          go-bin-deb generate --file .github/workflows/deb.json --wd . --version 0.0.1 --arch armel
+
+      -
+        name: Save artifacts
         uses: actions/upload-artifact@v3
         with:
           name: artifact
           path: |
-            ico
+            ico-dvd
+            *.deb
+
+      -
+        name: Prepare packaging & packagecloud CLI
+        run: |
+          sudo apt update
+          sudo apt install debhelper ruby-dev
+          sudo gem install package_cloud
+
+      -
+        name: Upload the package to packagecloud
+        env:
+          USERNAME: brainhackers
+          REPO: brainux/any/any
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+        run: |
+          package_cloud push "${USERNAME}/${REPO}" `ls *.deb`

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  push:
+  release:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deb.json
+++ b/.github/workflows/deb.json
@@ -1,0 +1,22 @@
+{
+    "name": "x11-ico-dvd",
+    "maintainer": "Takehiro Ogura <i@yude.jp>",
+    "version": "0.0.1",
+    "arch": "armel",
+    "files": [
+        {
+            "from": "ico-dvd",
+            "to": "/usr/bin",
+            "fperm": "0755"
+        }
+    ],
+    "copyrights": [
+        {
+            "files": "*",
+            "copyright": "1987 Digital Equipment Corporation, Maynard, Massachusetts.; 1987, 1994 X Consortium; 2005 Red Hat, Inc.; 2023 Brain Hackers",
+            "license": "Custom",
+            "file": "LICENSE"
+        }
+    ],
+    "description": "Animate an icosahedron or other polyhedron (with DVD mode)"
+}


### PR DESCRIPTION
This PR adds following:
- Packaging `brain-hackers/x11-ico` into `.deb`
- Publishing the package to packagecloud